### PR TITLE
UI 잠금 기능 추가: Ship의 Y축 회전을 Canvas에 적용하는 스크립트 생성

### DIFF
--- a/Assets/Scenes/TestSce.unity
+++ b/Assets/Scenes/TestSce.unity
@@ -145,7 +145,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5886209638148964557, guid: c1fab00001835f14b8cdd1ef99569305, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.64
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 5886209638148964557, guid: c1fab00001835f14b8cdd1ef99569305, type: 3}
       propertyPath: m_LocalPosition.z
@@ -317,81 +317,6 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
---- !u!1 &336826266
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 336826267}
-  - component: {fileID: 336826269}
-  - component: {fileID: 336826268}
-  m_Layer: 0
-  m_Name: Image
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &336826267
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 336826266}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 872982596}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1.2, y: 46.6}
-  m_SizeDelta: {x: 27, y: 35}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &336826268
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 336826266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -161341498, guid: 188cbc816a030bc43bb8ec5d138168d5, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &336826269
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 336826266}
-  m_CullTransparentMesh: 1
 --- !u!1 &605650062
 GameObject:
   m_ObjectHideFlags: 0
@@ -403,7 +328,7 @@ GameObject:
   - component: {fileID: 605650063}
   - component: {fileID: 605650065}
   - component: {fileID: 605650064}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: background
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -483,9 +408,9 @@ GameObject:
   - component: {fileID: 795275554}
   - component: {fileID: 795275559}
   - component: {fileID: 795275561}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Ship
-  m_TagString: Untagged
+  m_TagString: Ship
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -499,7 +424,7 @@ Transform:
   m_GameObject: {fileID: 795275551}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 12.7, y: 10.23, z: -0.59}
+  m_LocalPosition: {x: 12.7, y: 4, z: -0.59}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -657,7 +582,8 @@ GameObject:
   - component: {fileID: 872982599}
   - component: {fileID: 872982598}
   - component: {fileID: 872982597}
-  m_Layer: 0
+  - component: {fileID: 872982600}
+  m_Layer: 7
   m_Name: UI
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -677,7 +603,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1022336796}
-  - {fileID: 336826267}
   m_Father: {fileID: 795275552}
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -748,6 +673,18 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 2
   m_TargetDisplay: 0
+--- !u!114 &872982600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 872982595}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d7ae93639f14d143b5bfbf95507f790, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &960818257
 GameObject:
   m_ObjectHideFlags: 0
@@ -865,7 +802,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1022336796}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Cricle_Bar
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -889,63 +826,6 @@ Transform:
   - {fileID: 1914561760}
   m_Father: {fileID: 872982596}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1290449263
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.39
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.36
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1852038688064328979, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 6611888041700311656, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
-      propertyPath: m_Name
-      value: Ship (2)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 49fd519440dcc5f408e665ca02883893, type: 3}
 --- !u!1 &1604424630
 GameObject:
   m_ObjectHideFlags: 0
@@ -1049,7 +929,7 @@ Transform:
   m_GameObject: {fileID: 1604424630}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.74, z: 0}
+  m_LocalPosition: {x: 0, y: -3, z: 0}
   m_LocalScale: {x: 100, y: 1, z: 100}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1342,7 +1222,7 @@ GameObject:
   - component: {fileID: 1914561760}
   - component: {fileID: 1914561762}
   - component: {fileID: 1914561761}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: filled_bar
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1393,7 +1273,7 @@ MonoBehaviour:
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
-  m_FillAmount: 1
+  m_FillAmount: 0.75
   m_FillClockwise: 1
   m_FillOrigin: 2
   m_UseSpriteMesh: 0
@@ -1496,7 +1376,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6301417968983122358, guid: 21324ff6c7123e146b42578e12fdb2e6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 4.63
+      value: -75.7
       objectReference: {fileID: 0}
     - target: {fileID: 6301417968983122358, guid: 21324ff6c7123e146b42578e12fdb2e6, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -1534,27 +1414,6 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1649195059}
   m_SourcePrefab: {fileID: 100100000, guid: 21324ff6c7123e146b42578e12fdb2e6, type: 3}
---- !u!65 &73827252712410975
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8778181235079646896}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 11.048051, y: 4.1235886, z: 18.897806}
-  m_Center: {x: -0.48306602, y: 0.14598995, z: -15.701919}
 --- !u!1 &412580729941077582
 GameObject:
   m_ObjectHideFlags: 0
@@ -1619,29 +1478,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &6029255457823821316
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8778181235079646896}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &6050810788581604652
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8778181235079646896}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.080000475, y: 0, z: 5.66}
-  m_LocalScale: {x: 0.39999998, y: 1, z: 0.19999999}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6462970206214597300}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &6462970206214597300
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1653,8 +1489,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.82000005, y: 0.82, z: 0.82000005}
   m_ConstrainProportionsScale: 1
-  m_Children:
-  - {fileID: 6050810788581604652}
+  m_Children: []
   m_Father: {fileID: 795275552}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -1662,51 +1497,6 @@ RectTransform:
   m_AnchoredPosition: {x: -0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!23 &6511415581820414888
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8778181235079646896}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 77a2b57522b994640b4272daf291a45e, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!222 &7473497987772094230
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1715,25 +1505,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 412580729941077582}
   m_CullTransparentMesh: 1
---- !u!1 &8778181235079646896
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6050810788581604652}
-  - component: {fileID: 6029255457823821316}
-  - component: {fileID: 6511415581820414888}
-  - component: {fileID: 73827252712410975}
-  m_Layer: 7
-  m_Name: ShipBow
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!33 &8964746879706326524
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -1754,4 +1525,3 @@ SceneRoots:
   - {fileID: 2084038741}
   - {fileID: 1668895277}
   - {fileID: 960818261}
-  - {fileID: 1290449263}

--- a/Assets/Scripts/UI_lock.cs
+++ b/Assets/Scripts/UI_lock.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+public class Ui_lock : MonoBehaviour{
+    private Transform shipTransform;
+    private Canvas canvas;
+
+    void Start()
+    {
+        // Ship 프리팹 Transform 찾기
+        shipTransform = transform.parent;
+        canvas = GetComponent<Canvas>();
+    }
+
+    void LateUpdate()
+    {
+        if (shipTransform != null)
+        {
+            // Ship의 Y축 회전값을 Canvas의 Z축 회전에 적용
+            float yRotation = shipTransform.eulerAngles.y;
+            transform.localRotation = Quaternion.Euler(90, 0, yRotation);
+        }
+    }
+}

--- a/Assets/Scripts/UI_lock.cs.meta
+++ b/Assets/Scripts/UI_lock.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2d7ae93639f14d143b5bfbf95507f790


### PR DESCRIPTION
같은 프리팹 내에 자식 UI 캔버스 요소를 부모 ship 회전값을 z로 고정하여 UI 캔버스 고정함